### PR TITLE
Move Captan to the "Other" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A curated collection of open source fintech libraries and resources. This is not
 - [Budget](https://github.com/range-of-motion/budget) - a web application that helps you keep track of your finances by organizing and visualizing transactions
 - [Firefly III](https://github.com/firefly-iii/firefly-iii) - a self-hosted manager for personal finances to track expenses and income
 - [Ghostfolio](https://github.com/ghostfolio/ghostfolio) - a web-based wealth management application to keep track of your financial assets like stocks, ETFs or cryptocurrencies and make solid, data-driven investment
-- [Captan](https://github.com/acossta/captan) - a tiny, hackable CLI tool for managing startup cap tables. Provides real cap table math, vesting schedules, audit logs, and CSV/JSON export, requiring only git and JSON.
+- 
 decisions
 - [Mintable](https://github.com/kevinschaich/mintable) - automate personal finances without ads and data collection
 - [OnTrack](https://github.com/inoda/ontrack) - a simple, self-hosted budgeting app to understand and control spending without giving banking/financial info to a third party
@@ -103,7 +103,9 @@ decisions
 ## Other
 - [ach](https://github.com/moov-io/ach) - a reader, writer, and validator for Automated Clearing House (ACH) files
 - [Akaunting](https://github.com/akaunting/akaunting) - online accounting software designed for small businesses and freelancers
-- [Apache Fineract](https://github.com/apache/fineract) - core banking solution for financial institutions offering services to the world’s two billion underbanked and unbanked
+- [Apache Fineract](https://github.com/apache/f
+- - [Captan](https://github.com/acossta/captan) - a lightweight CLI for startup cap table management with real cap table math, vesting schedules, audit logs, and CSV/JSON exports; requires only git & JSON.
+ineract) - core banking solution for financial institutions offering services to the world’s two billion underbanked and unbanked
 - [fredapi](https://github.com/mortada/fredapi) - Python API for FRED (Federal Reserve Economic Data) and ALFRED (Archival FRED)
 - [go-finance](https://github.com/alpeb/go-finance) - Go library containing a collection of financial functions for time value of money (annuities), cash flow, interest rate conversions, bonds, and depreciation calculations
 - [Gringotts](https://github.com/aviabird/gringotts) - a simple and unified API to access dozens of different payment gateways with very different APIs, response schemas, documentation, and jargon


### PR DESCRIPTION
This PR moves **Captan** – a CLI tool for startup cap-table management – from the Personal finance section to the Other section. The Personal finance category is meant for budgeting and personal expense-tracking tools【815566932079877†L133-L147】, while the Other category includes various financial tools that aren't personal finance apps and are used by businesses or for general finance【815566932079877†L186-L217】. Captan is designed for startup equity and cap-table management (not personal budgeting), so it fits better in the Other section.