### PR TITLE
Add Strale to Compliance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Commercial projects can include a Github link to their source-available code for
 - [OpenSanctions](https://github.com/pudo/opensanctions) - an open database of international sanctions data, persons of interest, and politically exposed persons
 - [Watchman](https://github.com/moov-io/watchman) - offers search functions over numerous trade sanction lists from the United States
 
+- [Strale](https://github.com/strale-io/strale) - API capability marketplace for AI agents with 270+ quality-scored compliance and company data tools. PEP screening, adverse media checks, VAT validation, company registry lookups across 20+ countries, and bundled KYB solutions.
 ## Currency handling
 - [accounting](https://github.com/leekchan/accounting) - money and currency formatting for Golang
 - [accounting.js](https://github.com/openexchangerates/accounting.js) -  a tiny JavaScript library for number, money, and currency parsing/formatting

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Commercial projects can include a Github link to their source-available code for
 - [fincen](https://github.com/moov-io/fincen) - A Go library for reading and writing Fincen BSA forms. It is capable of generating, validating, and batching submissions.
 - [stripe-mcps](https://github.com/razashariff/stripe-mcps) - Cryptographic security layer for Stripe agent payments. Trust verification + sanctions screening before PaymentIntent execution.
 - [OpenSanctions](https://github.com/pudo/opensanctions) - an open database of international sanctions data, persons of interest, and politically exposed persons
+- [Strale](https://github.com/strale-io/strale) - quality-scored compliance APIs for AI agents: sanctions screening, PEP checks, company lookups, and KYB verification
 - [Watchman](https://github.com/moov-io/watchman) - offers search functions over numerous trade sanction lists from the United States
 
-- [Strale](https://github.com/strale-io/strale) - API capability marketplace for AI agents with 270+ quality-scored compliance and company data tools. PEP screening, adverse media checks, VAT validation, company registry lookups across 20+ countries, and bundled KYB solutions.
 ## Currency handling
 - [accounting](https://github.com/leekchan/accounting) - money and currency formatting for Golang
 - [accounting.js](https://github.com/openexchangerates/accounting.js) -  a tiny JavaScript library for number, money, and currency parsing/formatting


### PR DESCRIPTION
Adds [Strale](https://github.com/strale-io/strale) to the Compliance section.

Strale is an open-source API capability marketplace that lets AI agents execute 270+ quality-scored compliance and company data tools at runtime. Includes PEP screening (OpenSanctions), adverse media checks, VAT/EORI validation, company registry lookups across 20+ countries, and bundled KYB solutions. Every capability is independently tested with a public quality score (SQS).

- GitHub: https://github.com/strale-io/strale
- Website: https://strale.dev