### PR TITLE
Add fxmacrodata to Stock data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Commercial projects can include a Github link to their source-available code for
 
 ## Stock data
 - [fdnpy](https://github.com/financialdatanet/fdnpy) - Access real-time and historical stock data, financial statements, ratios, insider trades, with global coverage of equities, ETFs, indices, derivatives, OTC and crypto.
+- [fxmacrodata](https://github.com/fxmacrodata/fxmacrodata) - Python SDK for macroeconomic indicators, central bank rates, FX spot rates, and release calendars covering 18+ currencies. Includes sync and async clients.
 - [GoFinance](https://github.com/aktau/gofinance) - Financial information retrieval and munging written in Go
 - [Indicator Go](https://github.com/cinar/indicator) - Go library delivering a rich set of technical analysis indicators, customizable strategies, and a powerful backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) - TypeScript library delivering a rich set of technical analysis indicators, customizable strategies, and a powerful backtesting framework.


### PR DESCRIPTION
Adds [fxmacrodata](https://github.com/fxmacrodata/fxmacrodata) — a Python SDK for macroeconomic indicators, central bank rates, FX spot rates, and release calendars covering 18+ currencies.

- MIT licensed, actively maintained
- Sync and async clients
- Published on [PyPI](https://pypi.org/project/fxmacrodata/) (v1.0.0)
- Supports Python ≥ 3.9
- Free access to USD macro data; API key for non-USD