### PR TITLE
Add CoinPaprika and DexPaprika Python SDKs to Stock data

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Commercial projects can include a Github link to their source-available code for
 - [OnTrack](https://github.com/inoda/ontrack) - a simple, self-hosted budgeting app to understand and control spending without giving banking/financial info to a third party
 
 ## Stock data
+- [coinpaprika-api-python-client](https://github.com/coinpaprika/coinpaprika-api-python-client) - Python client for the CoinPaprika API providing crypto market data for 12,000+ coins and 350+ exchanges with tickers, OHLCV, and historical prices
+- [dexpaprika-sdk-python](https://github.com/coinpaprika/dexpaprika-sdk-python) - Python SDK for the DexPaprika API providing DEX analytics across 34 blockchains with pool data, token metadata, OHLCV charts, and real-time streaming
 - [fdnpy](https://github.com/financialdatanet/fdnpy) - Access real-time and historical stock data, financial statements, ratios, insider trades, with global coverage of equities, ETFs, indices, derivatives, OTC and crypto.
 - [GoFinance](https://github.com/aktau/gofinance) - Financial information retrieval and munging written in Go
 - [Indicator Go](https://github.com/cinar/indicator) - Go library delivering a rich set of technical analysis indicators, customizable strategies, and a powerful backtesting framework.


### PR DESCRIPTION
Adds two open-source Python SDKs for crypto market data to the Stock data section:

- **coinpaprika-api-python-client** — Python client for the CoinPaprika API (crypto market data: 12K+ coins, 350+ exchanges, tickers, OHLCV, historical prices)
- **dexpaprika-sdk-python** — Python SDK for the DexPaprika API (DEX analytics across 34 blockchains: pool data, token metadata, OHLCV, real-time streaming)

Both link to open-source GitHub repositories and are alphabetized within the section.