### PR TITLE
Add API Factory x402 — 100 x402 APIs for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Commercial projects can include a Github link to their source-available code for
 - [Akaunting](https://github.com/akaunting/akaunting) - online accounting software designed for small businesses and freelancers
 - [Apache Fineract](https://github.com/apache/fineract) - core banking solution for financial institutions offering services to the world’s two billion underbanked and unbanked
 - [awesome-x402](https://github.com/xpaysh/awesome-x402) - a curated list of resources for the x402 HTTP 402 payment protocol, enabling programmatic machine-to-machine payments using USDC over standard HTTP
+- [API Factory x402](https://github.com/Br0ski777/x402-agent-tools) - 100 x402 micropayment APIs for AI agents. USDC on Base.
 - [edgartools](https://github.com/dgunning/edgartools) - SEC EDGAR data for quant strategies — fundamentals, institutional holdings (13F), insider transactions, and corporate events (8-K). Includes MCP server for AI workflows
 - [fredapi](https://github.com/mortada/fredapi) - Python API for FRED (Federal Reserve Economic Data) and ALFRED (Archival FRED)
 - [go-finance](https://github.com/alpeb/go-finance) - Go library containing a collection of financial functions for time value of money (annuities), cash flow, interest rate conversions, bonds, and depreciation calculations


### PR DESCRIPTION
## Summary
- Adds **API Factory x402** to the Other section (alongside existing awesome-x402 entry)
- 100 production-ready x402 micropayment APIs for AI agents: crypto/DeFi, B2B enrichment, SEO, security, and 70+ utilities
- Pay-per-call USDC on Base. No API keys needed.

## Links
- GitHub: https://github.com/Br0ski777/x402-agent-tools
- npm: https://www.npmjs.com/package/x402-agent-tools
- Network: Base Mainnet (USDC)