### PR TITLE
Add Oracle3 to Data & Market Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Commercial projects can include a Github link to their source-available code for
 - [Indicator Go](https://github.com/cinar/indicator) – Go library delivering a rich set of technical analysis indicators, customizable strategies, and a powerful backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript library delivering a rich set of technical analysis indicators, customizable strategies, and a powerful backtesting framework.
 - [JCStockGraph](https://github.com/jconst/JCStockGraph) – display historical price graphs for any stock in your iOS app
-- [Oracle3](https://github.com/YichengYang-Ethan/oracle3) – Autonomous prediction-market trading agent for Kalshi, Polymarket, and Solana featuring a Wang-transform pricing engine, arbitrage strategies, Kelly sizing, and an optional MCP server (Python)
+- [Oracle3](https://github.com/YichengYang-Ethan/oracle3) – Autonomous prediction-market trading agent for Kalshi, Polymarket, and Solana featuring a Wang-transform pricing engine, arbitrage strategies, Kelly sizing, and on-chain execution via Jito bundles (Python)
 - [TuShare](https://github.com/waditu/tushare) – a utility for crawling historical data of China stocks
 - [yahoo-finance](https://github.com/lukaszbanasiak/yahoo-finance) – Python module to get stock data from Yahoo Finance
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Commercial projects can include a Github link to their source-available code for
 - [Indicator Go](https://github.com/cinar/indicator) – Go library delivering a rich set of technical analysis indicators, customizable strategies, and a powerful backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript library delivering a rich set of technical analysis indicators, customizable strategies, and a powerful backtesting framework.
 - [JCStockGraph](https://github.com/jconst/JCStockGraph) – display historical price graphs for any stock in your iOS app
-- [Oracle3](https://github.com/YichengYang-Ethan/oracle3) – autonomous prediction-market trading agent for Kalshi, Polymarket, and Solana featuring a Wang-transform pricing engine, arbitrage strategies, Kelly sizing, and an optional MCP server (Python).
+- [Oracle3](https://github.com/YichengYang-Ethan/oracle3) – Autonomous prediction-market trading agent for Kalshi, Polymarket, and Solana featuring a Wang-transform pricing engine, arbitrage strategies, Kelly sizing, and an optional MCP server (Python)
 - [TuShare](https://github.com/waditu/tushare) – a utility for crawling historical data of China stocks
 - [yahoo-finance](https://github.com/lukaszbanasiak/yahoo-finance) – Python module to get stock data from Yahoo Finance
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Commercial projects can include a Github link to their source-available code for
 - [Indicator Go](https://github.com/cinar/indicator) – Go library delivering a rich set of technical analysis indicators, customizable strategies, and a powerful backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript library delivering a rich set of technical analysis indicators, customizable strategies, and a powerful backtesting framework.
 - [JCStockGraph](https://github.com/jconst/JCStockGraph) – display historical price graphs for any stock in your iOS app
-- [Oracle3](https://github.com/YichengYang-Ethan/oracle3) – autonomous prediction-market trading agent for Kalshi, Polymarket, and Solana with a Wang-transform pricing engine calibrated on 291K+ resolved contracts, eight constraint-based arbitrage strategies, hierarchical MLE, model Greeks, Kelly sizing, and an optional MCP server (Python).
+- [Oracle3](https://github.com/YichengYang-Ethan/oracle3) – autonomous prediction-market trading agent for Kalshi, Polymarket, and Solana featuring a Wang-transform pricing engine, arbitrage strategies, Kelly sizing, and an optional MCP server (Python).
 - [TuShare](https://github.com/waditu/tushare) – a utility for crawling historical data of China stocks
 - [yahoo-finance](https://github.com/lukaszbanasiak/yahoo-finance) – Python module to get stock data from Yahoo Finance
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Commercial projects can include a Github link to their source-available code for
 - [Indicator Go](https://github.com/cinar/indicator) – Go library delivering a rich set of technical analysis indicators, customizable strategies, and a powerful backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript library delivering a rich set of technical analysis indicators, customizable strategies, and a powerful backtesting framework.
 - [JCStockGraph](https://github.com/jconst/JCStockGraph) – display historical price graphs for any stock in your iOS app
+- [Oracle3](https://github.com/YichengYang-Ethan/oracle3) – autonomous prediction-market trading agent for Kalshi, Polymarket, and Solana with a Wang-transform pricing engine calibrated on 291K+ resolved contracts, eight constraint-based arbitrage strategies, hierarchical MLE, model Greeks, Kelly sizing, and an optional MCP server (Python).
 - [TuShare](https://github.com/waditu/tushare) – a utility for crawling historical data of China stocks
 - [yahoo-finance](https://github.com/lukaszbanasiak/yahoo-finance) – Python module to get stock data from Yahoo Finance
 


### PR DESCRIPTION
## Summary

- Adds [Oracle3](https://github.com/YichengYang-Ethan/oracle3) to the **Data & Market Intelligence** section.
- Oracle3 is an autonomous prediction-market trading agent for Kalshi, Polymarket, and Solana / DFlow. It exposes a Wang-transform pricing engine calibrated on 291,309 resolved contracts (favorite-longshot bias λ̂ ≈ 0.183), eight constraint-based arbitrage strategies (cross-market, exclusivity, implication, conditional, event-sum, structural), hierarchical MLE, model Greeks, Kelly sizing, and on-chain execution via Jito bundles + Solana Memo audit trail.
- Backed by SSRN paper: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6468338
- Quality: 170 stars, Apache 2.0, v1.1.0, 633 tests, mkdocs site, CI for tests/ruff/mypy.
- Insertion is a single line, alphabetical (between `JCStockGraph` and `TuShare`).

## Checklist
- [x] Entry follows the existing format
- [x] Project is open source (Apache 2.0)
- [x] Project is actively maintained (633 tests, recent v1.1.0 release)
- [x] Description is concise and factual