### PR TITLE
Add FundsXML to Financial Data & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [EDGAR Tools](https://github.com/dgunning/edgartools) – Python toolkit for SEC EDGAR filings: 13F holdings, 8-K events, fundamentals, and insider transactions.
 - [FRED API](https://github.com/mortada/fredapi) – Python client for Federal Reserve Economic Data (FRED) and ALFRED macroeconomic series.
 - [Finance Go](https://github.com/piquette/finance-go) – Go library for financial markets data including stocks, quotes, and fundamentals.
+- [FundsXML](https://www.fundsxml.org/) – Open, royalty-free XML standard for fund data exchange and regulatory reporting across the European fund industry ([schema](https://github.com/fundsxml/schema)).
 - [Indicator Go](https://github.com/cinar/indicator) – Go library of technical analysis indicators, strategies, and backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript port of technical analysis indicators, strategies, and backtesting.
 - [TuShare](https://github.com/waditu/tushare) – Python utility for historical China equities market data (widely used in Asian quant workflows).


### PR DESCRIPTION
Adds **FundsXML** to the *Financial Data & APIs* section.

FundsXML is an open, royalty-free XML standard for fund data exchange and regulatory reporting across the European fund industry, used by asset managers, fund administrators, custodians, data vendors and authorities. The schema is published under the MIT License.

- Website: https://www.fundsxml.org/
- Schema (XSD): https://github.com/fundsxml/schema

Single entry, alphabetically placed; description kept concise to match the existing list style.