### PR TITLE
Add catchem to Financial Data & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [Indicator Go](https://github.com/cinar/indicator) – Go library of technical analysis indicators, strategies, and backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript port of technical analysis indicators, strategies, and backtesting.
 - [TuShare](https://github.com/waditu/tushare) – Python utility for historical China equities market data (widely used in Asian quant workflows).
+- [catchem](https://github.com/nazmiefearmutcu/catchem) – Local-first sidecar (Python + Tauri) that turns raw web text into multi-labeled `FinancialImpactRecord` events (asset class, impact reason, direction, time horizon, confidence) for analyst pipelines.
 
 ## Money, Currency & Formatting
 - [Dinero.js](https://github.com/dinerojs/dinero.js) – Immutable, chainable library for creating, calculating, and formatting monetary values (avoids floating point issues).


### PR DESCRIPTION
Adding [catchem](https://github.com/nazmiefearmutcu/catchem) to the **Financial Data & APIs** section.

catchem is a local-first sidecar (Python FastAPI engine + Tauri 2 React desktop UI) that turns raw web text into structured multi-labeled `FinancialImpactRecord` events. Each record carries:

- Asset class (equity / crypto / FX / commodity / rates / unknown)
- Impact reason (earnings / geopolitics / energy / employment / inflation / …)
- Direction (positive / negative / mixed / uncertain)
- Time horizon (intraday / short / medium / long)
- Component scores + confidence

Differentiator vs. existing entries: this is a **signal-generation** layer (raw text → labels), not a market-data API. Default mode is production-safe (CPU stubs); the real ML adapter is opt-in via a config flag and quarantined under a three-check release gate. MIT licensed, 220+ pytest + 30+ vitest.

Live README with screenshots: https://github.com/nazmiefearmutcu/catchem#preview