### PR TITLE
Add eupago Python SDK (Payments & Integrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [PayPal Checkout Components](https://github.com/paypal/paypal-checkout-components) – Official JavaScript integration components for PayPal Buttons and Checkout experiences.
 - [React Native Payments](https://github.com/naoufal/react-native-payments) – Cross-platform library for adding Apple Pay and Google Pay to React Native applications.
 - [Gringotts](https://github.com/aviabird/gringotts) – Unified API for integrating dozens of payment gateways in Elixir/Phoenix applications.
+- [eupago](https://github.com/bilouro/eupago-python) – First Python SDK for the eupago payment gateway (Portugal): MB WAY, Multibanco, credit cards, Pay By Link, refunds and webhooks. Sync + async, fully typed (mypy --strict).
 
 ## Banking Infrastructure
 - [Apache Fineract](https://github.com/apache/fineract) – Apache project providing core banking functionality used by financial institutions serving the underbanked.


### PR DESCRIPTION
## What

Adds [eupago-python](https://github.com/bilouro/eupago-python) — the first and currently only open-source Python SDK for **eupago**, Portugal's main payment gateway — to the **Payments & Integrations** section.

## Why it fits

- **Open source**, MIT licensed — same spirit as the rest of the list.
- **Production-ready**: every payment method (MB WAY, Multibanco, Credit Card, Pay By Link, refunds) has been live-validated against a real eupago production channel with real money. Five payments and three refunds emitted, all webhooks captured and verified end-to-end.
- **Modern Python**: fully typed (`mypy --strict`), `py.typed` marker, sync + async on the same client, Pydantic v2 models, Decimal for money, HMAC-verified webhooks (cleartext and AES-256-CBC encrypted).
- **Fills a real gap** in the Portuguese fintech ecosystem — until this SDK, integrating eupago from Python meant writing your own httpx wrapper against an API that has two coexisting generations with inconsistent field names.

## Stats

- 📦 [PyPI](https://pypi.org/project/eupago/) · 159 unit tests · 92% coverage · 16 integration tests (live sandbox)
- 📚 Bilingual docs (English + Português) on [GitHub Pages](https://bilouro.github.io/eupago-python/)
- 🏷 License: MIT

Happy to address any feedback — thanks for maintaining this list! 🙏