### PR TITLE
feat: The Stall — 209 pay-per-call AI capabilities via x402 MCP (v4.63.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [Indicator Go](https://github.com/cinar/indicator) – Go library of technical analysis indicators, strategies, and backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript port of technical analysis indicators, strategies, and backtesting.
 - [TuShare](https://github.com/waditu/tushare) – Python utility for historical China equities market data (widely used in Asian quant workflows).
+- [The Stall](https://github.com/thebrierfox/the-stall) – Remote pay-per-call MCP server with 198 financial data capabilities (US/EU/APAC stock prices, forex rates, DeFi protocol analytics, options chains, earnings calendars, congressional trades, on-chain intelligence) via x402 micropayments on Base mainnet. Any HTTP client or AI agent pays per query in USDC — no SDK, no API keys.
 
 ## Money, Currency & Formatting
 - [Dinero.js](https://github.com/dinerojs/dinero.js) – Immutable, chainable library for creating, calculating, and formatting monetary values (avoids floating point issues).


### PR DESCRIPTION
## The Stall — 209 pay-per-call AI capabilities (v4.63.1)

**Live:** https://the-stall.intuitek.ai | **MCP:** https://the-stall.intuitek.ai/mcp

The Stall is an x402 MCP server with 209 pay-per-call capabilities — AI agents pay USDC per call, no API keys needed.

**Coverage:** stocks, crypto, DeFi, insider trades, Form 144 planned sales, options, macro, congressional trades, weather, cron tools, domain intel, and 185+ more.

**New in v4.63.1:**
- `form-144-intel` — SEC Form 144 planned insider sale filings (pre-Form 4 signal, from EDGAR)
- `cron-parser` — parse and explain cron expressions, return next N run times

```json
{
  "mcpServers": {
    "the-stall": {
      "type": "streamable-http",
      "url": "https://the-stall.intuitek.ai/mcp"
    }
  }
}
```

git: eba2715 | version: v4.63.1 | caps: 200