### PR TITLE
Add Superhighway - M&A research agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [FRED API](https://github.com/mortada/fredapi) – Python client for Federal Reserve Economic Data (FRED) and ALFRED macroeconomic series.
 - [Finance Go](https://github.com/piquette/finance-go) – Go library for financial markets data including stocks, quotes, and fundamentals.
 - [FundsXML](https://www.fundsxml.org/) – Open, royalty-free XML standard for fund data exchange and regulatory reporting across the European fund industry ([schema](https://github.com/fundsxml/schema)).
+- [Superhighway M&A Research Agent](https://superhighway.walls.sh/guides/ma-research-agent) – Python agent that researches comparable M&A transactions, deal multiples, potential acquirers, and recent deal activity via live web search, producing structured M&A intelligence briefs. Pay-per-call, no signup.
 - [Indicator Go](https://github.com/cinar/indicator) – Go library of technical analysis indicators, strategies, and backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript port of technical analysis indicators, strategies, and backtesting.
 - [TuShare](https://github.com/waditu/tushare) – Python utility for historical China equities market data (widely used in Asian quant workflows).


### PR DESCRIPTION
Adds Superhighway's M&A research agent guide — a Python agent that researches comparable M&A transactions, deal multiples, potential acquirers, and recent M&A deal activity using live web search (/search, /scrape, /research, /news). Outputs structured M&A intelligence briefs with strategic rationale, comparable transactions, valuation multiples, regulatory considerations, and due diligence flags. Audience: corporate development, PE analysts, investment bankers, founders mapping exit paths. Pay-per-call, no signup. https://superhighway.walls.sh/guides/ma-research-agent