### PR TITLE
Add Agent Toolbelt to Financial Data & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [Watchman](https://github.com/moov-io/watchman) – Search across US trade sanctions lists (OFAC, etc.) for compliance screening.
 
 ## Financial Data & APIs
+- [Agent Toolbelt](https://www.agenttoolbelt.live) – Hosted AI stock-research API: returns structured analysis (investment thesis, valuation verdict, insider signal, earnings, watchlist ranking) from live fundamentals, as JSON. Free tier + paid plans.
 - [EDGAR Tools](https://github.com/dgunning/edgartools) – Python toolkit for SEC EDGAR filings: 13F holdings, 8-K events, fundamentals, and insider transactions.
 - [FRED API](https://github.com/mortada/fredapi) – Python client for Federal Reserve Economic Data (FRED) and ALFRED macroeconomic series.
 - [Finance Go](https://github.com/piquette/finance-go) – Go library for financial markets data including stocks, quotes, and fundamentals.


### PR DESCRIPTION
Adds **Agent Toolbelt** to the Financial Data & APIs section (alphabetical, first entry).

Agent Toolbelt is a hosted AI stock-research API: ticker in, structured *analysis* out — investment thesis, valuation verdict, insider-signal read, earnings track record, and watchlist ranking — generated from live fundamentals (Polygon/Finnhub/FMP) and returned as JSON, rather than raw market data.

Transparency note: unlike most entries in this section, this is a **hosted/commercial API** (not an open-source library), though it has a free tier (no credit card). Happy to adjust placement or wording — or close it — if you'd prefer to keep the section OSS-only.