### PR TITLE
feat: add VeraData to Compliance & Sanctions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [OpenSanctions](https://github.com/opensanctions/opensanctions) – Open database and tools for sanctions lists, politically exposed persons (PEP), and persons of interest used in KYC/AML.
 - [Watchman](https://github.com/moov-io/watchman) – Search across US trade sanctions lists (OFAC, etc.) for compliance screening.
 
+- [VeraData](https://api.veradata.dev) – LATAM compliance API: sanctions screening against OFAC+UN+EU+UK (59,454 entries), KYB for CO/MX/BR/CL/PE (business registry + risk narrative), and real-time central bank rates (TRM, TIIE, Selic, UF, dólar blue). EU AI Act Art.12/13 audit trail. MCP-native, x402 micropayments.
 ## Financial Data & APIs
 - [EDGAR Tools](https://github.com/dgunning/edgartools) – Python toolkit for SEC EDGAR filings: 13F holdings, 8-K events, fundamentals, and insider transactions.
 - [FRED API](https://github.com/mortada/fredapi) – Python client for Federal Reserve Economic Data (FRED) and ALFRED macroeconomic series.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 
 ## Compliance & Sanctions
 - [OpenSanctions](https://github.com/opensanctions/opensanctions) – Open database and tools for sanctions lists, politically exposed persons (PEP), and persons of interest used in KYC/AML.
+- [VeraData](https://github.com/teodorofodocrispin-cmyk/veradata-public) – LATAM compliance API: sanctions screening OFAC+UN+EU+UK (59k+ entries), KYB for CO/MX/BR/CL/PE with EU AI Act Art.12/13 audit trail. MCP-native.
 - [Watchman](https://github.com/moov-io/watchman) – Search across US trade sanctions lists (OFAC, etc.) for compliance screening.
 
-- [VeraData](https://api.veradata.dev) – LATAM compliance API: sanctions screening against OFAC+UN+EU+UK (59,454 entries), KYB for CO/MX/BR/CL/PE (business registry + risk narrative), and real-time central bank rates (TRM, TIIE, Selic, UF, dólar blue). EU AI Act Art.12/13 audit trail. MCP-native, x402 micropayments.
 ## Financial Data & APIs
 - [EDGAR Tools](https://github.com/dgunning/edgartools) – Python toolkit for SEC EDGAR filings: 13F holdings, 8-K events, fundamentals, and insider transactions.
 - [FRED API](https://github.com/mortada/fredapi) – Python client for Federal Reserve Economic Data (FRED) and ALFRED macroeconomic series.


### PR DESCRIPTION
## Summary

Adds [VeraData](https://api.veradata.dev) to the **Compliance & Sanctions** section.

VeraData is a LATAM-native compliance API covering:
- **Sanctions screening** — OFAC SDN + UN Consolidated + EU Consolidated + UK HM Treasury (59,454 entries total)
- **KYB bundles** for Colombia, Mexico, Brazil, Chile, and Peru — business registry (RUES/CNPJ/RFC/RUT/RUC) + sanctions check + AI risk narrative in one call
- **Real-time central bank rates** — TRM (Colombia), TIIE (Mexico), Selic (Brazil), UF (Chile), BCRP (Peru), dólar blue (Argentina)
- **EU AI Act Art.12/13** immutable audit trail with SHA-256 hash chain
- **MCP-native** — MCP endpoint at `https://api.veradata.dev/mcp` for AI agent integration
- **x402 micropayments** — agents pay $0.01–$0.15 USDC per call, no API key or subscription required

**Why it fits Compliance & Sanctions:** VeraData fills the LATAM gap that OpenSanctions and Watchman don't cover — LATAM-specific business registries (RUES, CNPJ, RFC), SARLAFT compliance patterns, and a unified API that combines sanctions + KYB in a single call for each jurisdiction.

Trial: `curl -X POST https://api.veradata.dev/sanctions -H 'X-TRIAL: true' -H 'Content-Type: application/json' -d '{"name": "test"}'`