### PR TITLE
Add IBANforge to Banking Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [ISO 8583 Connection](https://github.com/moov-io/iso8583-connection) – Connection handling and request/reply matching for ISO 8583 in Go.
 - [Wire](https://github.com/moov-io/wire) – Parser and writer for FedWire funds service files used for high-value US dollar transfers.
 - [Fed](https://github.com/moov-io/fed) – Fuzzy lookup library for FedACH and FedWire ABA routing numbers and bank names.
+- [IBANforge](https://github.com/cammac-creator/ibanforge) – REST API and MCP server for IBAN validation (SWIFT registry patterns, 89 countries), BIC/SWIFT lookup (121k+ entries, LEI-enriched via GLEIF), Swiss SIC/euroSIC clearing data, and sanctions/FATF pre-checks.
 - [Metro 2](https://github.com/moov-io/metro2) – Parser and generator for Metro 2 consumer credit reporting files used by credit bureaus.
 - [JReactive-8583](https://github.com/kpavlov/jreactive-8583) – Netty-based ISO 8583 client and server for Java.
 - [ISO-8583 Socket Queue](https://github.com/juks/iso-8583-socket-queue) – Node.js ISO 8583 gateway for banking and POS system communication.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [ISO 8583 Connection](https://github.com/moov-io/iso8583-connection) – Connection handling and request/reply matching for ISO 8583 in Go.
 - [Wire](https://github.com/moov-io/wire) – Parser and writer for FedWire funds service files used for high-value US dollar transfers.
 - [Fed](https://github.com/moov-io/fed) – Fuzzy lookup library for FedACH and FedWire ABA routing numbers and bank names.
-- [IBANforge](https://github.com/cammac-creator/ibanforge) – REST API and MCP server for IBAN validation (SWIFT registry patterns, 89 countries), BIC/SWIFT lookup (121k+ entries, LEI-enriched via GLEIF), Swiss SIC/euroSIC clearing data, and sanctions/FATF pre-checks.
+- [IBANforge](https://github.com/cammac-creator/ibanforge) – REST API and MCP server for IBAN validation, BIC/SWIFT lookup, and Swiss SIC clearing data, with sanctions and FATF pre-checks.
 - [Metro 2](https://github.com/moov-io/metro2) – Parser and generator for Metro 2 consumer credit reporting files used by credit bureaus.
 - [JReactive-8583](https://github.com/kpavlov/jreactive-8583) – Netty-based ISO 8583 client and server for Java.
 - [ISO-8583 Socket Queue](https://github.com/juks/iso-8583-socket-queue) – Node.js ISO 8583 gateway for banking and POS system communication.


### PR DESCRIPTION
Adds [IBANforge](https://github.com/cammac-creator/ibanforge) next to Fed (same job for the IBAN world as Fed does for ABA routing numbers: resolve an account identifier into the real institution and its rails).

What it covers:
- IBAN validation against the SWIFT registry BBAN patterns (89 countries), not just mod-97
- BIC/SWIFT lookup backed by 121k+ entries (38k+ LEI-enriched via GLEIF, refreshed monthly)
- Swiss clearing depth: ~1,200 SIX BankMaster entries with SIC/euroSIC/instant participation and QR-IID handling
- Sanctions (OFAC/EU/UN) + FATF pre-checks with a 0-100 risk score
- MCP server for AI agents, free tier (200 req/month), OpenAPI spec, Docker self-hostable

Disclosure: I'm the author. Entry follows the list's one-line format and sits alphabetically-adjacent to Fed in Banking Infrastructure; happy to move it to Compliance & Sanctions if you prefer.