### PR TITLE
Add honest-signals to Financial Data & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [FRED API](https://github.com/mortada/fredapi) – Python client for Federal Reserve Economic Data (FRED) and ALFRED macroeconomic series.
 - [Finance Go](https://github.com/piquette/finance-go) – Go library for financial markets data including stocks, quotes, and fundamentals.
 - [FundsXML](https://www.fundsxml.org/) – Open, royalty-free XML standard for fund data exchange and regulatory reporting across the European fund industry ([schema](https://github.com/fundsxml/schema)).
+- [honest-signals](https://github.com/MarvinRey7879/honest-signals) – Python CLI and library that scores detected chart patterns against the pattern-free baseline for the same market and timeframe, reporting lift with cluster-robust confidence intervals.
 - [Indicator Go](https://github.com/cinar/indicator) – Go library of technical analysis indicators, strategies, and backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript port of technical analysis indicators, strategies, and backtesting.
 - [TuShare](https://github.com/waditu/tushare) – Python utility for historical China equities market data (widely used in Asian quant workflows).


### PR DESCRIPTION
Adds one entry under **Financial Data & APIs**, alphabetically between FundsXML and Indicator Go, using the section's existing en-dash format.

[honest-signals](https://github.com/MarvinRey7879/honest-signals) — MIT, Python 3.10+.

The list already carries several technical-analysis libraries that compute indicators and patterns. This one checks whether those signals mean anything. Pattern hit rates are conventionally read against a 50% reference, which is the wrong reference in a market that drifts: over 46,038 independent 10-bar windows on the daily US stock corpus, price closed higher 57.84% of the time and lower 42.00% with no pattern present at all. So a "bearish engulfing hits only 41.3%" result is 0.7pp away from the market's own drift — nothing.

The tool prints each detected pattern's hit rate beside the pattern-free baseline for the same universe, timeframe, horizon and direction, and reports the difference with a cluster-robust interval on that difference (clustered on the UTC day, since the same-day occurrences across tickers are not independent draws). Applied across 105 measured cells, that method calls 3 of them findings where a naive interval would call 14 — and none survives correction for the number of comparisons.

**Disclosure:** I wrote it, and it reads from the patternfetch API, which I also run. It works against a keyless public endpoint, so it needs no account or key to evaluate:

```bash
git clone https://github.com/MarvinRey7879/honest-signals && cd honest-signals
pip install -e ".[cli]"
honest-signals check MSFT SPY NVDA
```

CI green, 219 tests, active this week. Not yet on PyPI, so the link points at the repo.