### PR TITLE
Add Logos Bancos BR to Financial Data & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [FundsXML](https://www.fundsxml.org/) – Open, royalty-free XML standard for fund data exchange and regulatory reporting across the European fund industry ([schema](https://github.com/fundsxml/schema)).
 - [Indicator Go](https://github.com/cinar/indicator) – Go library of technical analysis indicators, strategies, and backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript port of technical analysis indicators, strategies, and backtesting.
+- [Logos Bancos BR](https://github.com/rzmt/logos-bancos-br) – Dataset and official logos of Brazilian financial institutions (banks, fintechs, payment institutions, cooperatives), built only from Central Bank (STR/Pix) participant lists and the Open Finance directory, with per-logo provenance and weekly auto-updates.
 - [TuShare](https://github.com/waditu/tushare) – Python utility for historical China equities market data (widely used in Asian quant workflows).
 
 ## Money, Currency & Formatting


### PR DESCRIPTION
Adds **Logos Bancos BR** to the *Financial Data & APIs* section.

It's a dataset + official logos of Brazilian financial institutions (banks, fintechs, payment institutions, cooperatives), built **only from official sources**: the Central Bank's STR and Pix participant lists and the Open Finance Brasil directory. Every logo ships with provenance (source URI, SHA-256, date), and the whole dataset is rebuilt weekly by CI.

Meets the list's criteria:
- **Utility**: resolves ISPB/COMPE codes and serves logos for any Brazilian bank/fintech — a common need in payments, onboarding and statement UIs.
- **Adoption / maintenance**: published on npm, consumable via CDN (jsDelivr) with no install; weekly automated updates from the official sources.
- **Licensing**: MIT — https://github.com/rzmt/logos-bancos-br

Not a personal finance app, crypto, or AI experiment. Entry placed alphabetically; single line, en-dash, per the existing format.