### PR TITLE
Add Sanwo to Payments & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [PayPal Checkout Components](https://github.com/paypal/paypal-checkout-components) – Official JavaScript integration components for PayPal Buttons and Checkout experiences.
 - [React Native Payments](https://github.com/naoufal/react-native-payments) – Cross-platform library for adding Apple Pay and Google Pay to React Native applications.
 - [Gringotts](https://github.com/aviabird/gringotts) – Unified API for integrating dozens of payment gateways in Elixir/Phoenix applications.
+- [Sanwo](https://github.com/Sanwohq/core) – Open source, provider-agnostic payment SDK with native implementations for React, Vue, Svelte, React Native, Flutter, iOS, and Android. Supports Paystack, Flutterwave, Razorpay, Monnify, Interswitch, and custom providers.
 
 ## Banking Infrastructure
 - [Apache Fineract](https://github.com/apache/fineract) – Apache project providing core banking functionality used by financial institutions serving the underbanked.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [PayPal Checkout Components](https://github.com/paypal/paypal-checkout-components) – Official JavaScript integration components for PayPal Buttons and Checkout experiences.
 - [React Native Payments](https://github.com/naoufal/react-native-payments) – Cross-platform library for adding Apple Pay and Google Pay to React Native applications.
 - [Gringotts](https://github.com/aviabird/gringotts) – Unified API for integrating dozens of payment gateways in Elixir/Phoenix applications.
-- [Sanwo](https://github.com/Sanwohq/core) – Open source, provider-agnostic payment SDK with native implementations for React, Vue, Svelte, React Native, Flutter, iOS, and Android. Supports Paystack, Flutterwave, Razorpay, Monnify, Interswitch, and custom providers.
+- [Sanwo](https://github.com/Sanwohq) – Open source, provider-agnostic payment SDK with native implementations for React, Vue, Svelte, React Native, Flutter, iOS, and Android. Supports Paystack, Flutterwave, Razorpay, Monnify, Interswitch, and custom providers.
 
 ## Banking Infrastructure
 - [Apache Fineract](https://github.com/apache/fineract) – Apache project providing core banking functionality used by financial institutions serving the underbanked.


### PR DESCRIPTION
## Summary

Adds [Sanwo](https://github.com/Sanwohq/core) to the Payments & Integrations section.

Sanwo is an open-source, provider-agnostic payment SDK that unifies multiple payment gateways behind a single API. It ships native SDKs for 9 platforms (Web, React, Vue, Svelte, React Native, Flutter, iOS/Swift, Android/Kotlin) and supports 5 providers out of the box (Paystack, Flutterwave, Razorpay, Monnify, Interswitch) plus custom provider templates.

- **License:** Apache-2.0
- **Docs:** https://docs.sanwo.dev
- **npm:** https://www.npmjs.com/org/sanwohq
- **Active maintenance:** Published across npm, pub.dev, JitPack, and SPM