### PR TITLE
Add Funding Signals to Financial Data & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [EDGAR Tools](https://github.com/dgunning/edgartools) – Python toolkit for SEC EDGAR filings: 13F holdings, 8-K events, fundamentals, and insider transactions.
 - [FRED API](https://github.com/mortada/fredapi) – Python client for Federal Reserve Economic Data (FRED) and ALFRED macroeconomic series.
 - [Finance Go](https://github.com/piquette/finance-go) – Go library for financial markets data including stocks, quotes, and fundamentals.
+- [Funding Signals](https://fundingsignals.net/docs) – REST API that surfaces companies the moment they raise capital from public SEC Form D filings, scored 0-100 as sales leads with domain/contact enrichment.
 - [FundsXML](https://www.fundsxml.org/) – Open, royalty-free XML standard for fund data exchange and regulatory reporting across the European fund industry ([schema](https://github.com/fundsxml/schema)).
 - [Indicator Go](https://github.com/cinar/indicator) – Go library of technical analysis indicators, strategies, and backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript port of technical analysis indicators, strategies, and backtesting.


### PR DESCRIPTION
Adds Funding Signals — a REST API that surfaces companies the moment they raise capital from public SEC Form D filings, scored 0-100 as sales leads with domain/contact enrichment. Free tier available, no card required. Fits alongside EDGAR Tools as a SEC-filings-derived data source. Docs: https://fundingsignals.net/docs