### PR TITLE
Add payday-super-checker (Australian superannuation deadline compliance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 ## Compliance & Sanctions
 - [OpenSanctions](https://github.com/opensanctions/opensanctions) – Open database and tools for sanctions lists, politically exposed persons (PEP), and persons of interest used in KYC/AML.
 - [Watchman](https://github.com/moov-io/watchman) – Search across US trade sanctions lists (OFAC, etc.) for compliance screening.
+- [payday-super-checker](https://github.com/ryanduguid/payday-super-checker) – Check Australian superannuation contributions against the payday-super deadlines (in force from 1 July 2026) and estimate SG charge exposure on late ones.
 
 ## Financial Data & APIs
 - [EDGAR Tools](https://github.com/dgunning/edgartools) – Python toolkit for SEC EDGAR filings: 13F holdings, 8-K events, fundamentals, and insider transactions.


### PR DESCRIPTION
Adds [payday-super-checker](https://github.com/ryanduguid/payday-super-checker) to Compliance & Sanctions.

Since 1 July 2026, Australian employers must get superannuation contributions into the employee's fund within 7 business days of each payday (Treasury Laws Amendment (Payday Superannuation) Act 2025). This CLI checks payroll CSV exports against those deadlines and estimates the resulting superannuation guarantee charge on late lines, with the statutory assumptions printed alongside every figure.

Python, MIT licensed, no runtime dependencies, CI-gated releases. Importer profiles for Xero, MYOB and Employment Hero payroll exports.

Compliance & Sanctions looked like the nearest fit since the list has no payroll/tax section; happy to move it wherever you prefer, or split a section if that's cleaner.