### PR TITLE
Add Pakistan Mutual Funds API to Financial Data & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [FundsXML](https://www.fundsxml.org/) – Open, royalty-free XML standard for fund data exchange and regulatory reporting across the European fund industry ([schema](https://github.com/fundsxml/schema)).
 - [Indicator Go](https://github.com/cinar/indicator) – Go library of technical analysis indicators, strategies, and backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript port of technical analysis indicators, strategies, and backtesting.
+- [Pakistan Mutual Funds API](https://github.com/saadsalmankhan/pakistan-mutual-funds-api) – Self-hosted scraper and REST API for Pakistani mutual fund NAVs, sourced from MUFAP's public Fund Directory.
 - [TuShare](https://github.com/waditu/tushare) – Python utility for historical China equities market data (widely used in Asian quant workflows).
 
 ## Money, Currency & Formatting


### PR DESCRIPTION
Adds [Pakistan Mutual Funds API](https://github.com/saadsalmankhan/pakistan-mutual-funds-api) under **Financial Data & APIs**.

It is an open-source (MIT), self-hosted scraper and REST API that exposes current NAVs and offer prices for ~550 Pakistani mutual funds, sourced from MUFAP's public Fund Directory. It is a practical building block for anyone building fintech or investment tooling for the Pakistani market, where clean programmatic access to fund NAVs is otherwise hard to come by.

- Language: TypeScript / Node (Express + cheerio)
- License: MIT
- Serves JSON from a local cache, with a configurable scheduler
- Placed alphabetically in the Financial Data & APIs section