### PR TITLE
Add Statementproof to Financial Data & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 - [FundsXML](https://www.fundsxml.org/) – Open, royalty-free XML standard for fund data exchange and regulatory reporting across the European fund industry ([schema](https://github.com/fundsxml/schema)).
 - [Indicator Go](https://github.com/cinar/indicator) – Go library of technical analysis indicators, strategies, and backtesting framework.
 - [Indicator TS](https://github.com/cinar/indicatorts) – TypeScript port of technical analysis indicators, strategies, and backtesting.
+- [Statementproof](https://github.com/OrbitalKeyAi/statementproof) – Python CLI that extracts transactions from bank statement PDFs and verifies the result against the statement's own opening, closing and running balances, reporting which row fails to reconcile.
 - [TuShare](https://github.com/waditu/tushare) – Python utility for historical China equities market data (widely used in Asian quant workflows).
 
 ## Money, Currency & Formatting


### PR DESCRIPTION
Adds [Statementproof](https://github.com/OrbitalKeyAi/statementproof), placed alphabetically in **Financial Data & APIs**.

It extracts transactions from text-layer bank statement PDFs and then validates the extraction against the statement's own opening/closing balances and running-balance column. When the arithmetic doesn't reconcile it names the specific row that broke the chain; when a statement carries no balances to check against it reports `UNVERIFIED` rather than implying the output is correct.

Relevant to this list because silent extraction errors in financial documents are a real correctness problem — a debit misread as a credit reconciles to nothing and surfaces later inside someone's books. It reads word coordinates rather than flattened text so debit and credit columns stay distinguishable, and infers which column is the running balance from arithmetic rather than header text.

MIT, runs entirely locally: no networking library is imported anywhere in the package, enforced by a test that parses every module's AST.

Disclosure: I'm the author. Happy to reword, shorten, or move sections if there's a better fit.