### PR TITLE
ci: automerge Renovate dependency PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,26 @@
         "digest"
       ],
       "automerge": true
+    },
+    {
+      "description": "Automerge GitHub Actions updates (including majors)",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Keep docker/image majors out of grouped update-all PRs and do not automerge them",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "docker major",
+      "automerge": false
     }
   ],
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "groupName": "all"
 }


### PR DESCRIPTION
Automerge minor/patch/pin/digest and GitHub Actions updates (including action majors) with platformAutomerge. Docker/image majors are split into their own group and not auto-merged.