### PR TITLE
Add edgar-geo-revenue to Financial Data & APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Projects must demonstrate meaningful adoption (stars, forks, contributors, or in
 
 ## Financial Data & APIs
 - [EDGAR Tools](https://github.com/dgunning/edgartools) – Python toolkit for SEC EDGAR filings: 13F holdings, 8-K events, fundamentals, and insider transactions.
+- [edgar-geo-revenue](https://github.com/Metricshour/edgar-geo-revenue) – Python library to extract geographic revenue breakdowns from SEC EDGAR 10-K filings (no API key).
 - [FRED API](https://github.com/mortada/fredapi) – Python client for Federal Reserve Economic Data (FRED) and ALFRED macroeconomic series.
 - [Finance Go](https://github.com/piquette/finance-go) – Go library for financial markets data including stocks, quotes, and fundamentals.
 - [FundsXML](https://www.fundsxml.org/) – Open, royalty-free XML standard for fund data exchange and regulatory reporting across the European fund industry ([schema](https://github.com/fundsxml/schema)).


### PR DESCRIPTION
## Summary
Adds [edgar-geo-revenue](https://github.com/Metricshour/edgar-geo-revenue) under **Financial Data & APIs**, next to EDGAR Tools.

- Open-source Python library (MIT) for geographic revenue from SEC EDGAR 10-Ks
- No API key; two dependencies (`requests`, `beautifulsoup4`)
- `pip install edgar-geo-revenue`
- PyPI: https://pypi.org/project/edgar-geo-revenue/
- Docs + examples: https://metricshour.github.io/edgar-geo-revenue/
- License: MIT

Complements edgartools with a focused geo-segment revenue extractor for fundamental analysis pipelines.